### PR TITLE
Fix typo (warrantee -> warranty)

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ title: "bitcoinj"
 
 <p><b>Important announcements</b>: If you use bitcoinj in an application please sign up for <a href="https://groups.google.com/forum/?fromgroups#!forum/bitcoinj-announce">the announcement list</a> so you know when new versions are available and if there are critical bugs found.</p>
 
-<p><b>Be aware</b>: this library is Apache licensed. By using it, you agree with the terms of that license. In particular pay attention to section 7 and 8, which assert <b>there is NO WARRANTEE that this library is safe to use or bug free, and in fact that by using this code you accept that none of the contributors shall be liable for any damages or monetary loss that results from your use of their code, even if due to bugs in that code</b>. In short, according to the license the library is distributed under, there are no situations in which you could sue any of the developers (it's as if you wrote the entire library yourself). If you can't handle that, don't use this library.</p>
+<p><b>Be aware</b>: this library is Apache licensed. By using it, you agree with the terms of that license. In particular pay attention to section 7 and 8, which assert <b>there is NO WARRANTY that this library is safe to use or bug free, and in fact that by using this code you accept that none of the contributors shall be liable for any damages or monetary loss that results from your use of their code, even if due to bugs in that code</b>. In short, according to the license the library is distributed under, there are no situations in which you could sue any of the developers (it's as if you wrote the entire library yourself). If you can't handle that, don't use this library.</p>
 
 <h1 id="documentation">Documentation</h1>
 


### PR DESCRIPTION
One word change to fix a typo.
