### PR TITLE
Remove extra level of header nesting in languages (other than JavaScript)

### DIFF
--- a/using-from-other-languages.md
+++ b/using-from-other-languages.md
@@ -24,7 +24,7 @@ This page details how you can go about using bitcoinj from other languages.
 
 Javascript can interop with Java using the Nashorn engine shipped in Java 8. We have a tutorial on this already! Check out the getting started guide to learn how to set this up and see some examples. Javascript programs that access Java libraries can be run from the command line using the "jjs" tool. There are projects that provide the Node.js API's as well.
 
-###C++
+##C++
 
 At the moment, the easiest way to use bitcoinj from C++ is to embed the JVM and use auto-generated JNI wrappers. Here's an example of what such a program looks like:
 
@@ -46,21 +46,21 @@ Callback interfaces (`WalletListener`, `PeerEventListener` etc) have to be bound
 
 We are also exploring complete automated conversion of the bitcoinj sources into C++, so it could be used without any JVM at all. However this work is at an earlier, less usable stage.
 
-###Objective-C
+##Objective-C
 
 The Hive team maintain a library called [BitcoinKit](https://github.com/hivewallet/BitcoinKit), which is designed for building wallet apps on MacOS X. It does not expose the raw bitcoinj API, rather providing its own Objective-C API on top and using JNI under the covers.
 
-###Python
+##Python
 
 Python has many fans and can be fun to prototype in. The original Python implementation cannot interop with Java code, but we can gain access via another way using [Jython](http://www.jython.org/index.html). Jython is an implementation of Python (2.x) that is compatible with the original language/class libraries and provides an interactive interpreter that works just like regular Python's for exploration and learning. As long as you don't rely on any custom CPython extensions, you can just run your regular Python application out of the box, including UNIX style executable scripts.
 
 Why would you do that? Primarily because you can import Java class libraries as you would Python class libraries (from org.bitcoinj.core import Wallet). You also get a better garbage collector and real multi-threading support.
 
-###Ruby
+##Ruby
 
 In a similar vein to Jython, there is also [JRuby](http://jruby.org/).  Like Jython it runs Ruby on the JVM, with the same advantages - an excellent garbage collector, interop with Java code, real multi-threading support and so on. Like Jython the only thing it has issues with is modules that rely on C extension functions, but anything pure Ruby works.
 
-###Lisp
+##Lisp
 
 The block explorer at biteasy.com is written in Clojure, a dialect of Lisp that runs on the JVM. It uses bitcoinj directly.
 


### PR DESCRIPTION
All language besides JavaScript had one extra level of header
nesting/indenting.  That is they have ### instead of ## so it looks
like they’re nested under JavaScript. This PR removes the extra #.