### PR TITLE
Fix markdown headlines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+gem 'jekyll'
+gem 'jekyll-watch'
+gem 'kramdown'
+gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.1.2)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.1)
+      listen (~> 3.0)
+    kramdown (1.10.0)
+    liquid (3.0.6)
+    listen (3.0.6)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9.7)
+    mercenary (0.3.5)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.21)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-watch
+  kramdown
+  rouge
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
The headlines are currently broken on the website which is probably caused by a resent update of the jekyll and markdown on GH pages. 

The reason is that markdown requires a space between the #  and the heading text. 
I've also updated the jekyll configuration for the latest version.

locally it looks fine now, hope it works for GH pages, too.