### PR TITLE
Using new command generate for newer bitcoin-cli

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -39,6 +39,11 @@ and once that's running, in another window you can do something like
 ~~~
 ./bitcoin-cli -regtest setgenerate true 101
 ~~~
+(if you are using an older bitcoin-core version) respectively 
+~~~
+./bitcoin-cli -regtest generate 101
+~~~
+(if you are using bitcoin-core 0.11.0 or later)
 
 ... to create a new block on demand. Regtest mode requires the usage of yet another set of network params, `RegTestParams.get()`, and is designed to run only locally. There is no public regtest network. You can use `PeerGroup.connectToLocalHost()` to make it talk to the local bitcoind.
 
@@ -48,6 +53,12 @@ Note that newly mined coins have to mature (this is a general Bitcoin rule). Thi
 ./bitcoin-cli -regtest sendtoaddress <address of your app goes here> 10.0
 ./bitcoin-cli -regtest setgenerate true 1
 ~~~
+(for older bitcoin-core versions) respectively
+~~~
+./bitcoin-cli -regtest sendtoaddress <address of your app goes here> 10.0
+./bitcoin-cli -regtest generate 1
+~~~
+(for newer bitcoin-core versions)
 
 The block chain and so on is stored in ~/.bitcoin/regtest, so you can delete it to start over again, or use -datadir to make the files be saved in a different location.
 


### PR DESCRIPTION
The command `setgenerate` has been replaced in newer bitcoin-cli versions with `generate`.