### PR TITLE
Replace IRC references/links with our Matrix room

### DIFF
--- a/getting-started-js.md
+++ b/getting-started-js.md
@@ -148,6 +148,6 @@ There are many other features in bitcoinj that this tutorial does not cover. You
 
 There is another Javascript example that implements the same forwarding program as the Java tutorial, [forwarding.js](https://github.com/bitcoinj/bitcoinj/blob/master/examples/src/main/javascript/forwarding.js). You can read that program to learn how to use the wallet and how to receive and send money.
 
-Have fun and if you have any questions, find us on IRC or the mailing list.
+Have fun and if you have any questions, find us on Matrix or the mailing list.
 
 </div>

--- a/index.html
+++ b/index.html
@@ -106,5 +106,5 @@ title: "bitcoinj"
   <li>View <a href="https://github.com/bitcoinj/bitcoinj">bitcoinj on Github</a> - make sure to <q>star</q> us!</li>
   <li>Ask questions and discuss improvements on the <a href="https://groups.google.com/forum/#!forum/bitcoinj">mailing list</a></li>
   <li>Search and report issues on the <a href="https://github.com/bitcoinj/bitcoinj/issues">Issues Data Base</a> (to ask for help please use the mailing list, not the Issues DB)</li>
-  <li>Join our IRC channel, #bitcoinj on <a href="http://webchat.freenode.net/?channels=bitcoinj&uio=d4">freenode</a>.</li>
+  <li>Join our <a href="https://www.matrix.org">Matrix</a> room: <a href="https://matrix.to/#/#bitcoinj:matrix.org">#bitcoinj:matrix.org</a>.</li>
 </ul>


### PR DESCRIPTION
Replace IRC with Matrix

Our public Matrix room is: [#bitcoinj:matrix.org](https://matrix.to/#/#bitcoinj:matrix.org)