### PR TITLE
Getting Started Java: Bring up to date (as of 0.16 release)

### DIFF
--- a/getting-started-java.md
+++ b/getting-started-java.md
@@ -14,34 +14,34 @@ title: "Getting started in Java"
 
 ## Initial setup
 
-bitcoinj has logging and assertions built in. Assertions are always checked by default regardless of whether the -ea flag is specified. Logging is handled by the [SLF4J](http://www.slf4j.org) library. It lets you choose which logging system you'd prefer to use, eg, JDK logging, Android logging, etc. By default we use the simple logger which prints most stuff of interest to stderr. You can pick a new logger by switching out the jar file in the lib directory.
+**bitcoinj** has logging and assertions built in. Assertions are always checked by default regardless of whether the `-ea` flag is specified. Logging is handled by the [SLF4J](http://www.slf4j.org) library. It lets you choose which logging system you'd prefer to use, eg, JDK logging, Android logging, etc. By default we use the simple logger which prints most stuff of interest to stderr. You can pick a new logger by switching out the jar file in the lib directory.
 
-bitcoinj uses Maven as its build system and is distributed via git. There are source code/jar downloads you can use, but it's more secure to get it directly from the source repository.
+**bitcoinj** uses Gradle as its build system and is distributed via git. There are source code/jar downloads you can use, but it's more secure to get it directly from the source repository.
 
-To get the code and install it, grab [Maven](https://maven.apache.org) or [Gradle](https://gradle.org), and add it to your path. Also make sure you have git installed. Probably your Java IDE has some Maven/Gradle and Git integration too, but having them available via the command line is still very useful.
+To get the code and install it, grab [Maven](https://maven.apache.org) or [Gradle](https://gradle.org), and add it to your path. Also make sure you have Git installed. Probably your Java IDE has some Maven/Gradle and Git integration too, but having them available via the command line is still very useful.
 
 Now get the latest version of the code. You can use the instructions on the [Using Maven](/using-maven) or [Using Gradle](/using-gradle) page - just run the commands there and you'll get the right version of the code (unless this website is itself compromised). This is intended to protect against compromised mirrors or source downloads - because git works using source tree hashes, if you get a source hash in the right manner, you are guaranteed to end up with the right code.
 
-You can [read the full program here](https://github.com/bitcoinj/bitcoinj/blob/master/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java).
+You can [read the full program here](https://github.com/bitcoinj/bitcoinj/blob/release-0.16/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java).
 
 ## Basic structure
 
-A bitcoinj application uses the following objects:
+A **bitcoinj** application uses the following objects:
 
  * a `NetworkParameters` instance which selects the network (production or test) you are on.
  * a `Wallet` instance to store your `ECKey`s and other data.
  * a `PeerGroup` instance to manage the network connections.
  * a `BlockChain` instance which manages the shared, global data structure which makes Bitcoin work.
- * a `BlockStore` instance which keeps the block chain data structure somewhere, like on disk.
+ * a `BlockStore` instance which keeps the blockchain data structure somewhere, like on disk.
  * `WalletEventListener` implementations, which receive wallet events.
 
-To simplify setting them up, there is also a `WalletAppKit` object that creates the above objects and connects them together. Whilst you can do this manually (and for most "real" apps you would), this demo app shows how to use the app kit.
+To simplify setting them up, there is also a `WalletAppKit` object that creates the above objects and connects them together. While you can do this manually (and for most "real" apps you would), this demo app shows how to use the app kit.
 
 Let's go through the code and see how it works.
 
 # Setup
 
-We use a utility function to configure log4j to have more compact, less verbose log formatting. Then we check the command line arguments.
+We use a utility function to configure logging to have more compact, less verbose log formatting. Then we check the command line arguments.
 
 {% highlight java %}
 BriefLogFormatter.init();
@@ -75,11 +75,11 @@ There are multiple separate, independent Bitcoin networks:
 * The public test network (testnet) which is reset from time to time and exists for us to play about with new features. 
 * Regression test mode, which is not a public network and requires you to run a bitcoin daemon with the -regtest flag yourself.
 
-Each network has its own genesis block, its own port number and its own address prefix bytes to prevent you accidentally trying to send coins across networks (which won't work). These facts are encapsulated into a `NetworkParameters` singleton object. As you can see, each network has its own class and you fetch the relevant `NetworkParameters` object by calling `get()` on one of those objects.
+Each network has its own genesis block, its own port number and its own address prefix bytes to prevent you accidentally trying to send coins across networks (which won't work). These facts are encapsulated in a `NetworkParameters` singleton object. As you can see, each network has its own class and you fetch the relevant `NetworkParameters` object by calling `get()` on one of those objects.
 
-It's strongly recommended that you develop your software on the testnet or using regtest mode. If you accidentally lose test coins, it's no big deal as they are valueless, and you can get lots of them for free from a [TestNet Faucet](http://faucet.xeno-genesis.com/). Make sure to send the coins back to the faucet when you're done with them, so others can use them too.
+It's strongly recommended that you develop your software on the testnet or using regtest mode. If you accidentally lose test coins, it's no big deal as they are valueless, and you can get lots of them for free from a _TestNet faucet_. Make sure to send the coins back to the faucet when you're done with them, so others can use them too.
 
-In regtest mode there's no public infrastructure, but you can get a new block whenever you want without having to wait for one by running `"bitcoind -regtest setgenerate true"` on the same machine as the regtest mode bitcoind is running.
+In regtest mode there's no public infrastructure, but you can get a new block whenever you want without having to wait for one by running `"bitcoin-cli -regtest -generate"` on the same machine as the regtest-mode bitcoind is running.
 
 ## Keys and addresses
 
@@ -99,8 +99,6 @@ Because an address encodes the network for which the key is intended to be used,
 bitcoinj consists of various layers, each of which operates at a lower level than the last. A typical application that wants to send and receive money needs at least a `BlockChain`, a `BlockStore`, a `PeerGroup` and a `Wallet`. All those objects need to be connected to each other so data flows correctly. Read ["How things fit together"](/how-things-fit-together) for more information on how data flows through a bitcoinj based application.
 
 To simplify this process, which often amounts to boilerplate, we provide a high level wrapper called `WalletAppKit`. It configures bitcoinj in _simplified payment verification_ mode (as opposed to full verification), which is the most appropriate mode to choose at this time unless you are an expert and wish to experiment with the (incomplete, likely buggy) full mode. It provides a few simple properties and hooks to let you modify the default configuration.
-
-In future, there may be more kits that configure bitcoinj differently for different kinds of applications that may have different needs. But for now, there's only one.
 
 {% highlight java %}
 // Start up a basic app using a class that automates some boilerplate. Ensure we always have at least one key.
@@ -134,9 +132,9 @@ Here, we simply check that the wallet has at least one key, and if not we add a 
 
 Next up, we check if we're using regtest mode. If we are, then we tell the kit to connect only to localhost where a bitcoind in regtest mode is expected to be running.
 
-Finally, we call `kit.startAsync()`. `WalletAppKit` is a [Guava Service](https://code.google.com/p/guava-libraries/wiki/ServiceExplained). Guava is a widely used utility library from Google that augments the standard Java library with some useful additional features. A service is an object that can be started and stopped (but only once), and you can receive callbacks when it finishes starting up or shutting down. You can also just block the calling thread until it's started with `awaitRunning()`, which is what we do here.
+Finally, we call `kit.startAsync()`. `WalletAppKit` is a [Guava Service](https://github.com/google/guava/wiki/ServiceExplained). Guava is a widely used utility library from Google that augments the standard Java library with some useful additional features. A service is an object that can be started and stopped (but only once), and you can receive callbacks when it finishes starting up or shutting down. You can also just block the calling thread until it's started with `awaitRunning()`, which is what we do here.
 
-The `WalletAppKit` will consider itself started when the block chain has been fully synced, which can sometimes take a while. You can [learn about how to make this faster](/speeding-up-chain-sync), but for a toy demo app it's not needed to implement any extra optimisations.
+The `WalletAppKit` will consider itself started when the blockchain has been fully synced, which can sometimes take a while. You can [learn about how to make this faster](/speeding-up-chain-sync), but for a toy demo app it's not needed to implement any extra optimisations.
 
 The kit has accessors on it that give access to the underlying objects it configures. You can't call these (they will assert) until the class is either started or in the process of starting up, because the objects would not be created.
 
@@ -144,14 +142,14 @@ After the app has started up, you'll notice there are two files in the directory
 
 ## Handling events
 
-We want to know when we receive money so we can forward it. This is an _event_ and like most Java APIs in bitcoinj you learn about events by registering _event listeners_, which are just objects that implement an interface. There are a handful of event listener interfaces in the library:
+We want to know when we receive money so that we can forward it. This is an _event_ and like most Java APIs in bitcoinj you learn about events by registering _event listeners_, which are just objects that implement an interface. There are a handful of event listener interfaces in the library:
 
 * `WalletEventListener` - for things that happen to your wallet
-* `BlockChainListener` - for events related to the block chain
+* `BlockChainListener` - for events related to the blockchain
 * `PeerEventListener` - for events related to a peer in the network
 * `TransactionConfidence.Listener` - for events related to the level of rollback security a transaction has
 
-Most apps don't need to use all of these. Because each interface provides a group of related events and you probably don't care about all of them.
+Most apps don't need to use all of these. Each interface provides a group of related events -- you probably don't care about all of them.
 
 {% highlight java %}
 kit.wallet().addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
@@ -168,7 +166,7 @@ Events in bitcoinj are run in a dedicated background thread that's just used for
 
 Most widget toolkits like Swing, JavaFX or Android have what is called _thread affinity_, meaning you can only use them from a single thread. To get back from a background thread to the main thread, you normally pass a closure to some utility function that schedules the closure to be run when the GUI thread is idle.
 
-To simplify the task of writing GUI apps with bitcoinj, you can specify an arbitrary [Executor](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executor.html) whenever you register an event listener. That executor will be asked to run the event listener. By default, this means passing the given `Runnable` to the user thread, but you can override that like this:
+To simplify the task of writing GUI apps with bitcoinj, you can specify an arbitrary [Executor](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html) whenever you register an event listener. That executor will be asked to run the event listener. By default, this means passing the given `Runnable` to the user thread, but you can override that like this:
 
 {% highlight java %}
 Executor runInUIThread = new Executor() {
@@ -192,7 +190,7 @@ Because this can get repetitive and annoying, you can also change the default ex
 Threading.USER_THREAD = runInUIThread;
 {% endhighlight %}
 
-In some cases bitcoinj can generate a large number of events very fast, this is typical when syncing the block chain with a wallet that has a lot of transactions in it as each one can generate a transaction confidence changed event (as they get buried deeper and deeper). It's very likely that in future the way wallet events work will change to avoid this problem, but for now that's how the API works. If the user thread falls behind then memory bloat can occur as event listener invocations queue up on the heap. To avoid this, you can register event handlers with `Threading.SAME_THREAD` as the executor, in which case they will run immediately on bitcoinj controlled background threads. However you must be exceptionally careful when using this mode - any exceptions that occur in your code may unwind bitcoinj stacks and cause peer disconnection, also, re-entering the library may cause lock inversions or other issues. Generally you should avoid doing it unless you really need the extra performance and know exactly what you're doing.
+In some cases bitcoinj can generate a large number of events very fast, this is typical when syncing the blockchain with a wallet that has a lot of transactions in it as each one can generate a transaction confidence changed event (as they get buried deeper and deeper). It's very likely that in future the way wallet events work will change to avoid this problem, but for now that's how the API works. If the user thread falls behind then memory bloat can occur as event listener invocations queue up on the heap. To avoid this, you can register event handlers with `Threading.SAME_THREAD` as the executor, in which case they will run immediately on bitcoinj controlled background threads. However, you must be exceptionally careful when using this mode - any exceptions that occur in your code may unwind bitcoinj stacks and cause peer disconnection, also, re-entering the library may cause lock inversions or other issues. Generally you should avoid doing it unless you really need the extra performance and know exactly what you're doing.
 
 ## Receiving money
 
@@ -238,7 +236,7 @@ Every transaction has a confidence object associated with it. The notion of _con
 
 _Confidence objects_ contain data we can use to make risk based decisions about how likely we are to have actually received money. They can also help us learn when confidence changes or reaches a certain threshold.
 
-_Futures_ are an important concept in concurrent programming and bitcoinj makes heavy use of them, in particular, we use the Guava extension to the standard Java `Future` class, which is called [ListenableFuture](https://code.google.com/p/guava-libraries/wiki/ListenableFutureExplained). A `ListenableFuture` represents the result of some future calculation or state. You can wait for it to complete (blocking the calling thread), or register a callback that will be invoked. Futures can also fail, in which case you get back an exception instead of a result.
+_Futures_ are an important concept in concurrent programming and bitcoinj makes heavy use of them, in particular, we use the Guava extension to the standard Java `Future` class, which is called [ListenableFuture](https://github.com/google/guava/wiki/ListenableFutureExplained). A `ListenableFuture` represents the result of some future calculation or state. You can wait for it to complete (blocking the calling thread), or register a callback that will be invoked. Futures can also fail, in which case you get back an exception instead of a result.
 
 Here we request a _depth future_. This future completes when a transaction is buried by at least that many blocks in the chain. A depth of one means it appeared in the top block in the chain. So here, we're saying "run this code when the transaction has at least one confirmation". Normally you'd use a utility method called `Futures.addCallback`, although there is another way to register listeners as well which can be seen in the code snippet below.
 


### PR DESCRIPTION
* Fix out-of-date text (e.g. name and params of `bitcoin-cli` executable)
* Fix obsolete and broken links (faucet link was actually malicious)
* Link to `release-0.16` branch for `ForwardingService.java`
* Minor grammatical and formatting improvements

 I did not thoroughly review or update the inline code samples, but a quick glance didn't spot anything obviously out-of-date.