### PR TITLE
index, getting-started, working-with-contracts: remove mention of mailing list

### DIFF
--- a/getting-started-js.md
+++ b/getting-started-js.md
@@ -148,6 +148,6 @@ There are many other features in bitcoinj that this tutorial does not cover. You
 
 There is another Javascript example that implements the same forwarding program as the Java tutorial, [forwarding.js](https://github.com/bitcoinj/bitcoinj/blob/master/examples/src/main/javascript/forwarding.js). You can read that program to learn how to use the wallet and how to receive and send money.
 
-Have fun and if you have any questions, find us on Matrix or the mailing list.
+Have fun and if you have any questions, please ask the [community](/#community) for advice.
 
 </div>

--- a/getting-started.md
+++ b/getting-started.md
@@ -29,7 +29,7 @@ This library is not like other libraries. A Bitcoin API allows you to directly h
 
 **FAILURE TO UNDERSTAND WHAT YOU ARE DOING CAN CAUSE MONEY TO BE STOLEN OR PERMANENTLY DESTROYED**
 
-These documents will help you learn how to use bitcoinj, but they are not yet completely comprehensive. If you are ever in any doubt at all, or just want some code review, please ask on our mailing list or on our forum for advice and a second opinion. Also, make sure you keep up with the latest versions of the software. Bug fixes happen all the time and any one of them could be required for the safety of your wallet. It's important that you frequently rebase onto new versions of the library, even though bitcoinj does not have a stable API.
+These documents will help you learn how to use bitcoinj, but they are not yet completely comprehensive. If you are ever in any doubt at all, or just want some code review, please ask the [community](/#community) for advice and a second opinion. Also, make sure you keep up with the latest versions of the software. Bug fixes happen all the time and any one of them could be required for the safety of your wallet. It's important that you frequently rebase onto new versions of the library, even though bitcoinj does not have a stable API.
 
 ## Pick your language
 

--- a/index.html
+++ b/index.html
@@ -109,7 +109,6 @@ title: "bitcoinj"
       <li>A bitcoinj-developers room (visible after joining the space) for discussion among developers working on (contributing to) bitcoinj.
     </ul>
   </li>
-  <li>Ask questions and discuss improvements on the <a href="https://groups.google.com/forum/#!forum/bitcoinj">mailing list</a></li>
-  <li>Search and report issues on the <a href="https://github.com/bitcoinj/bitcoinj/issues">Issues Data Base</a> (to ask for help please use the mailing list, not the Issues DB)</li>
+  <li>Search and report issues on the <a href="https://github.com/bitcoinj/bitcoinj/issues">Issues Data Base</a> (to ask for help please use the Matrix rooms above, not the Issues DB)</li>
   <li>View <a href="https://github.com/bitcoinj/bitcoinj">bitcoinj on Github</a> - make sure to <q>star</q> us!</li>
 </ul>

--- a/working-with-contracts.md
+++ b/working-with-contracts.md
@@ -20,7 +20,7 @@ _How to design and implement contract based applications._
 
 [Contracts](https://en.bitcoin.it/wiki/Contracts) are an exciting feature of Bitcoin that has opened up a new research field - using flexible digital money to produce compelling and innovative applications. The linked wiki page contains some examples of what can be done, but it can sometimes be unclear how to convert them into code.
 
-In this article, we'll look at a few common techniques that are used when implementing contract-based applications. It assumes you're already familiar with how the Bitcoin protocol works and have understood the theory on the contracts page - if something is unclear, please ask on the mailing list.
+In this article, we'll look at a few common techniques that are used when implementing contract-based applications. It assumes you're already familiar with how the Bitcoin protocol works and have understood the theory on the contracts page - if something is unclear, please ask the [community](/#community) for advice.
 
 ## Creating multi-signature outputs
 


### PR DESCRIPTION
I think it's time to sunset the mailing list. We've had three legitimate posts in 2023 and two in 2024 so far, but there is tons of spam. Also the motivation to help those on the mailing list seems low, replying to a chat is just much less cumbersome.

I propose, timeline tbd:

* Remove mentions of mailing list from documentation (this PR)
* Post to the mailing list it's going to be close
* After some time, close it for new posts
* Keep it around for archive purposes, but after a couple of years we maybe can delete it entirely